### PR TITLE
Update impute.R to clarify impute_gmt_titers

### DIFF
--- a/R/impute.R
+++ b/R/impute.R
@@ -34,12 +34,12 @@ impute_gmt_logtiters <- function(result, titers) {
 #' Impute censored titers
 #'
 #' This function takes a vector of titers and imputes censored titers based on
-#' the results of a geometric mean titer estimate from the `impute_gmt_titers()`
+#' the results of a geometric mean titer estimate from the `titertools::gmt()`
 #' function. Censored titers are drawn from a censored normal distribution with
 #' mean and standard deviation parameters equal to those provided in the
 #' result argument.
 #'
-#' @param result Results from a titer GMT estimate from `impute_gmt_titers()`
+#' @param result Results from a titer GMT estimate from `titertools::gmt()`
 #' @param titers A vector of titers for which to impute censored cases
 #'
 #' @return Returns a vector of titers with imputed values in place of censored


### PR DESCRIPTION
clarifies the required input `result` which is resulting table of `titertools::gmt()` in `impute_gmt_titers(result, titers)` 